### PR TITLE
First attempt of proposing /var/lib/libvirt

### DIFF
--- a/control/installation.xml
+++ b/control/installation.xml
@@ -30,7 +30,156 @@ textdomain="control"
                 <order config:type="integer">2000</order>
                 <!-- the rest is overlaid over the feature sections and values. -->
                 <partitioning>
-                  <try_separate_home config:type="boolean">false</try_separate_home>
+                  <!-- The whole list of volumes and the whole section for proposal settings
+                       need to be defined here because the SLES control file still uses the
+                       legacy pre storage-ng format, not based in a list of volumes. Maybe
+                       this section could be simplified once SLES adopts the new format in the
+                       default control.xml -->
+
+                  <proposal>
+                    <windows_delete_mode config:type="symbol">all</windows_delete_mode>
+                    <linux_delete_mode config:type="symbol">ondemand</linux_delete_mode>
+                    <other_delete_mode config:type="symbol">ondemand</other_delete_mode>
+                  </proposal>
+
+                  <volumes config:type="list">
+                    <volume>
+                      <mount_point>/</mount_point>
+                      <fs_type>btrfs</fs_type>
+                      <desired_size config:type="disksize">10 GiB</desired_size>
+                      <min_size config:type="disksize">5 GiB</min_size>
+                      <max_size config:type="disksize">30 GiB</max_size>
+                      <weight config:type="integer">20</weight>
+
+                      <snapshots config:type="boolean">true</snapshots>
+                      <snapshots_configurable config:type="boolean">true</snapshots_configurable>
+                      <snapshots_percentage config:type="integer">300</snapshots_percentage>
+
+                      <!-- Disable snapshots for / if disabling /var/lib/libvirt is not enough
+                           to fit in the disk -->
+                      <disable_order config:type="integer">2</disable_order>
+
+                      <!-- the default subvolume "@" was requested by product management -->
+                      <btrfs_default_subvolume>@</btrfs_default_subvolume>
+
+                      <!-- Subvolumes to be created for a Btrfs root file system -->
+                      <!-- copy_on_write is true by default -->
+                      <subvolumes config:type="list">
+                        <subvolume>
+                          <path>home</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>opt</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>srv</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>tmp</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>usr/local</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/cache</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/crash</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/lib/libvirt/images</path>
+                          <copy_on_write config:type="boolean">false</copy_on_write>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/lib/machines</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/lib/mailman</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/lib/mariadb</path>
+                          <copy_on_write config:type="boolean">false</copy_on_write>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/lib/mysql</path>
+                          <copy_on_write config:type="boolean">false</copy_on_write>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/lib/named</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/lib/pgsql</path>
+                          <copy_on_write config:type="boolean">false</copy_on_write>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/log</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/opt</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/spool</path>
+                        </subvolume>
+                        <subvolume>
+                          <path>var/tmp</path>
+                        </subvolume>
+
+                        <!-- architecture specific subvolumes -->
+
+                        <subvolume>
+                          <path>boot/grub2/i386-pc</path>
+                          <archs>i386,x86_64</archs>
+                        </subvolume>
+                        <subvolume>
+                          <path>boot/grub2/x86_64-efi</path>
+                          <archs>x86_64</archs>
+                        </subvolume>
+                        <subvolume>
+                          <path>boot/grub2/powerpc-ieee1275</path>
+                          <archs>ppc,!board_powernv</archs>
+                        </subvolume>
+                        <subvolume>
+                          <path>boot/grub2/x86_64-efi</path>
+                          <archs>x86_64</archs>
+                        </subvolume>
+                        <subvolume>
+                          <path>boot/grub2/s390x-emu</path>
+                          <archs>s390</archs>
+                        </subvolume>
+                      </subvolumes>
+                    </volume>
+
+                    <!-- The libvirt partition/lv -->
+                    <volume>
+                      <mount_point>/var/lib/libvirt</mount_point>
+                      <fs_type>xfs</fs_type>
+                      <fs_types>xfs,ext3,ext4</fs_types>
+
+                      <proposed config:type="boolean">true</proposed>
+                      <proposed_configurable config:type="boolean">true</proposed_configurable>
+                      <!-- Disable it in first place if we don't fit in the disk -->
+                      <disable_order config:type="integer">1</disable_order>
+
+                      <desired_size config:type="disksize">15 GiB</desired_size>
+                      <min_size config:type="disksize">5 GiB</min_size>
+                      <max_size config:type="disksize">unlimited</max_size>
+                      <weight config:type="integer">70</weight>
+                      <!-- If this volume is disabled, we want "/" to become greedy (unlimited
+                           max), since it will contain /var/lib/libvirt -->
+                      <fallback_for_max_size>/</fallback_for_max_size>
+                    </volume>
+
+                    <!-- swap partition -->
+                    <volume>
+                      <mount_point>swap</mount_point>
+                      <fs_type>swap</fs_type>
+
+                      <desired_size config:type="disksize">1 GiB</desired_size>
+                      <min_size config:type="disksize">512 MiB</min_size>
+                      <max_size config:type="disksize">2 GiB</max_size>
+                      <weight config:type="integer">10</weight>
+                    </volume>
+                  </volumes>
                 </partitioning>
                 <software>
                   <default_patterns>base kvm_server</default_patterns>

--- a/package/system-role-kvm.changes
+++ b/package/system-role-kvm.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov  8 13:07:17 UTC 2017 - ancor@suse.com
+
+- Propose a separate /var/lib/libvirt partition or logical volume
+  using the new format in the <partitioning> format of the control
+  file (part of fate#324207).
+- 15.0.2
+
+-------------------------------------------------------------------
 Wed Oct  4 22:35:58 UTC 2017 - sflees@suse.de
 
 - Drop Minimal from software list, it doesn't exist anymore and

--- a/package/system-role-kvm.spec
+++ b/package/system-role-kvm.spec
@@ -35,7 +35,7 @@ BuildRequires:  yast2-installation-control >= 4.0.0
 
 Url:            https://github.com/yast/system-role-kvm
 AutoReqProv:    off
-Version:        15.0.1
+Version:        15.0.2
 Release:        0
 Summary:        Server KVM role definition
 License:        MIT


### PR DESCRIPTION
Replaces #5 (I messed it up with rebase and `git push -f`).

This uses the new proposal capabilities provided by yast-storage-ng and documented at [1] in order to propose `/var/lib/libvirt` instead of `/home` if the KVM/Xen role is selected.

The values (min, max, weight, fs_types, etc.) are inspired by #4, but this is just a first approach that will need to be refined over time.

This is how the proposal would look in a relatively small disk using btrfs snapshots (so a bigger `/` is needed).

![separate-libvirt-snapshots2](https://user-images.githubusercontent.com/3638289/32555007-de369278-c49b-11e7-8154-341cbf892f4a.png)

This is how the dialog would look in the guided setup.

![separate-libvirt-settings2](https://user-images.githubusercontent.com/3638289/32555049-f752fd28-c49b-11e7-8f63-b6a1ba031e4f.png)

And this is the same proposal without snapshots (less greedy `/`), just for completeness.

![separate-libvirt-no-snapshots2](https://user-images.githubusercontent.com/3638289/32555073-083d98d2-c49c-11e7-8829-7c3b8ecc097d.png)

[1] https://github.com/yast/yast-storage-ng/blob/master/doc/old_and_new_proposal.md