### PR TITLE
Revert "Remove partitioning info from description"

### DIFF
--- a/control/installation.xml
+++ b/control/installation.xml
@@ -15,6 +15,7 @@
   </kvm_host_role>
   <kvm_host_role_description>
     <label>• Kernel-based hypervisor and tools
+• Dedicated /var/lib/libvirt partition
 • Disable firewall, kdump services</label>
   </kvm_host_role_description>
 </texts>

--- a/package/system-role-kvm.changes
+++ b/package/system-role-kvm.changes
@@ -1,10 +1,4 @@
 -------------------------------------------------------------------
-Tue Sep 25 14:39:00 UTC 2018 - dgonzalez@suse.com
-
-- Delete partitioning information from description (fate#324713)
-- 15.0.8
-
--------------------------------------------------------------------
 Wed Jan 10 16:20:11 UTC 2018 - rbrown@suse.com
  
 - adjust subvolume list to have NoCOW /var instead of many

--- a/package/system-role-kvm.spec
+++ b/package/system-role-kvm.spec
@@ -35,7 +35,7 @@ BuildRequires:  yast2-installation-control >= 4.0.0
 
 Url:            https://github.com/yast/system-role-kvm
 AutoReqProv:    off
-Version:        15.0.8
+Version:        15.0.7
 Release:        0
 Summary:        Server KVM role definition
 License:        MIT


### PR DESCRIPTION
Reverts yast/system-role-kvm#11

Because there was a misunderstood and those changes are not wanted.